### PR TITLE
specify that cargo optimization requires --release

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To create an optimised version of the app:
 
 ```bash
 npm run build
-cargo build
+cargo build --release
 ```
 
 ## Built With


### PR DESCRIPTION
This patch adds `--release` to the optimized Cargo instructions.