### PR TITLE
add warning about git depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ cd svelte-rocket
 npm install
 ```
 
+> Note: if you download the Git repository manually, do so with the `--depth=1` option, as previously stored assets in the repository balloon the clone size to over 500MiB.
 
 ...then start Rocket server and [Vite](https://vitejs.dev) in two different terminals 
 


### PR DESCRIPTION
This patch adds a warning to use `--depth=1` if cloning with git, as the repository is 544MiB.